### PR TITLE
Refine change password form to provide current password

### DIFF
--- a/app/components/ui/toast.tsx
+++ b/app/components/ui/toast.tsx
@@ -28,6 +28,7 @@ const toastVariants = cva(
     variants: {
       variant: {
         default: "border bg-background",
+        success: "group border-emerald-900 bg-emerald-900 text-white",
         destructive:
           "destructive group border-destructive bg-destructive text-destructive-foreground",
       },

--- a/app/models/user-password.server.ts
+++ b/app/models/user-password.server.ts
@@ -13,8 +13,28 @@ export const query = {
 }
 
 export const mutation = {
-  async update({ id, password }: z.infer<typeof schemaUserUpdatePassword>) {
+  async update({
+    id,
+    password,
+    currentPassword,
+  }: z.infer<typeof schemaUserUpdatePassword>) {
     const hashedPassword = await bcrypt.hash(password, 10)
+
+    const userPassword = await prisma.userPassword.findUnique({
+      where: { userId: id },
+    })
+
+    const isCurrentPasswordCorrect = await bcrypt.compare(
+      currentPassword,
+      userPassword?.hash || "",
+    )
+    if (!isCurrentPasswordCorrect) {
+      return {
+        error: {
+          currentPassword: "Current password is incorrect, check again",
+        },
+      }
+    }
 
     const user = await prisma.user.update({
       where: { id },

--- a/app/models/user-password.server.ts
+++ b/app/models/user-password.server.ts
@@ -18,8 +18,6 @@ export const mutation = {
     password,
     currentPassword,
   }: z.infer<typeof schemaUserUpdatePassword>) {
-    const hashedPassword = await bcrypt.hash(password, 10)
-
     const userPassword = await prisma.userPassword.findUnique({
       where: { userId: id },
     })
@@ -36,6 +34,7 @@ export const mutation = {
       }
     }
 
+    const hashedPassword = await bcrypt.hash(password, 10)
     const user = await prisma.user.update({
       where: { id },
       data: { password: { update: { hash: hashedPassword } } },

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -27,7 +27,7 @@ import { authenticator } from "~/services"
 import { createCacheHeaders } from "~/utils"
 import { model } from "~/models"
 
-import { Layout } from "./components"
+import { Layout, Toaster } from "./components"
 import styles from "./globals.css"
 
 export const links: LinksFunction = () => [
@@ -109,6 +109,7 @@ export default function App() {
       </head>
       <body className="bg-stone-50 text-stone-950 dark:bg-stone-950 dark:text-stone-50">
         <Outlet />
+        <Toaster />
         <ScrollRestoration />
         <Scripts />
         <LiveReload />

--- a/app/routes/settings.password.tsx
+++ b/app/routes/settings.password.tsx
@@ -18,6 +18,7 @@ import { prisma } from "~/libs"
 import { delay } from "~/utils"
 import {
   Alert,
+  Anchor,
   ButtonLoading,
   FormDescription,
   FormField,
@@ -80,7 +81,7 @@ export function UserPasswordForm({ user }: { user: Pick<User, "id"> }) {
       form.ref.current?.reset()
       toast({ title: actionData.success, variant: "success" })
     }
-  }, [isSubmitting, form.ref, actionData?.success, toast])
+  }, [actionData?.success, form.ref, isSubmitting, toast])
 
   return (
     <Form {...form.props} replace method="PUT" className="space-y-6">
@@ -91,7 +92,7 @@ export function UserPasswordForm({ user }: { user: Pick<User, "id"> }) {
           <FormLabel htmlFor={currentPassword.id}>Current Password</FormLabel>
           <InputPassword
             {...conform.input(currentPassword)}
-            placeholder="Input your current password"
+            placeholder="Your current password"
             defaultValue=""
           />
           {currentPassword.error && (
@@ -104,8 +105,12 @@ export function UserPasswordForm({ user }: { user: Pick<User, "id"> }) {
         <FormField>
           <FormLabel htmlFor={password.id}>New Password</FormLabel>
           <FormDescription>
-            Make sure to save your new password safely in a password manager or
-            other secure method you prefer.
+            Make sure to save your new password safely in a password manager
+            like{" "}
+            <Anchor withColor href="https://bitwarden.com">
+              Bitwarden
+            </Anchor>{" "}
+            or other secure method you prefer.
           </FormDescription>
           <InputPassword
             {...conform.input(password)}
@@ -168,7 +173,7 @@ export async function action({ request }: ActionArgs) {
         error: result.error,
         success: "",
       })
-    return json({ ...submission, success: "Password Changed!" })
+    return json({ ...submission, success: "Password has been changed." })
   }
 
   return json({ ...parsed, success: "" })

--- a/app/routes/settings.password.tsx
+++ b/app/routes/settings.password.tsx
@@ -61,7 +61,7 @@ export function UserPasswordForm({ user }: { user: Pick<User, "id"> }) {
   const navigation = useNavigation()
   const isSubmitting = navigation.state === "submitting"
 
-  const [form, { id, password, confirmPassword }] = useForm<
+  const [form, { id, password, confirmPassword, currentPassword }] = useForm<
     z.infer<typeof schemaUserUpdatePassword>
   >({
     shouldValidate: "onSubmit",
@@ -75,6 +75,20 @@ export function UserPasswordForm({ user }: { user: Pick<User, "id"> }) {
     <Form {...form.props} replace method="PUT" className="space-y-6">
       <FormFieldSet disabled={isSubmitting}>
         <input hidden {...conform.input(id)} defaultValue={user.id} />
+
+        <FormField>
+          <FormLabel htmlFor={currentPassword.id}>Current Password</FormLabel>
+          <InputPassword
+            {...conform.input(currentPassword)}
+            placeholder="Input your current password"
+            defaultValue=""
+          />
+          {currentPassword.error && (
+            <Alert variant="destructive" id={currentPassword.errorId}>
+              {currentPassword.error}
+            </Alert>
+          )}
+        </FormField>
 
         <FormField>
           <FormLabel htmlFor={password.id}>New Password</FormLabel>

--- a/app/routes/settings.password.tsx
+++ b/app/routes/settings.password.tsx
@@ -24,6 +24,7 @@ import {
   FormFieldSet,
   FormLabel,
   InputPassword,
+  useToast,
 } from "~/components"
 import { model } from "~/models"
 import { schemaUserUpdatePassword } from "~/schemas"
@@ -62,6 +63,8 @@ export function UserPasswordForm({ user }: { user: Pick<User, "id"> }) {
   const navigation = useNavigation()
   const isSubmitting = navigation.state === "submitting"
 
+  const { toast } = useToast()
+
   const [form, { id, password, confirmPassword, currentPassword }] = useForm<
     z.infer<typeof schemaUserUpdatePassword>
   >({
@@ -75,8 +78,9 @@ export function UserPasswordForm({ user }: { user: Pick<User, "id"> }) {
   useEffect(() => {
     if (!isSubmitting && actionData?.success) {
       form.ref.current?.reset()
+      toast({ title: actionData.success, variant: "success" })
     }
-  }, [isSubmitting, form.ref, actionData?.success])
+  }, [isSubmitting, form.ref, actionData?.success, toast])
 
   return (
     <Form {...form.props} replace method="PUT" className="space-y-6">

--- a/app/schemas/user.ts
+++ b/app/schemas/user.ts
@@ -32,6 +32,7 @@ const password = z
   .min(8, "Password at least 8 characters")
   .max(100, "Password max of 100 characters")
 const confirmPassword = z.string()
+const currentPassword = z.string()
 
 const remember = z.boolean().optional()
 
@@ -85,6 +86,7 @@ export const schemaUserProfileBio = z.object({ id, bio })
 export const schemaUserUpdatePassword = z
   .object({
     id,
+    currentPassword,
     password,
     confirmPassword,
   })

--- a/app/schemas/user.ts
+++ b/app/schemas/user.ts
@@ -32,7 +32,11 @@ const password = z
   .min(8, "Password at least 8 characters")
   .max(100, "Password max of 100 characters")
 const confirmPassword = z.string()
-const currentPassword = z.string()
+const currentPassword = z
+  .string({
+    required_error: "Current password is required",
+  })
+  .min(1, "Current password is required")
 
 const remember = z.boolean().optional()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix #12 
Improve change password page to add current password field. 

## What is the current behavior?

The current behavior is user only input new password and confirm new password
![image](https://github.com/bearmentor/bearmentor/assets/26239542/81c93d8a-7c85-4767-91c4-66180fb2cade)


## What is the new behavior?

The new behavior is user must input current password too for change the password
![image](https://github.com/bearmentor/bearmentor/assets/26239542/20c701c9-6fe2-40a6-b0a9-aa98190b5f33)

when user input the wrong current password
![image](https://github.com/bearmentor/bearmentor/assets/26239542/c2fb8fa7-a07c-4d39-8658-9fbc14382ede)
